### PR TITLE
Fixes make clean to avoid root destruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ test: build
 	aws cloudformation deploy --template-file $(TEMPLATE) --stack-name aws-ecr-public --capabilities CAPABILITY_IAM
 
 clean:
-	rm -rf dist /
+	rm -rf dist
 	aws cloudformation delete-stack --stack-name aws-ecr-public


### PR DESCRIPTION
Make clean attempts to remove the root volume.
This is quite dangerous especially if you have done a sudo rm -rf <something else> . recently.
Just removed the slash as not necessary 
Fixes #2 